### PR TITLE
Fix 'NameError("name 'chassis' is not defined")' error in thermalctld log

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -745,18 +745,18 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.wait_time = self.INTERVAL
 
-        chassis = sonic_platform.platform.Platform().get_chassis()
+        self.chassis = sonic_platform.platform.Platform().get_chassis()
 
-        self.thermal_monitor = ThermalMonitor(chassis)
+        self.thermal_monitor = ThermalMonitor(self.chassis)
         self.thermal_monitor.task_run()
 
         self.thermal_manager = None
         try:
-            self.thermal_manager = chassis.get_thermal_manager()
+            self.thermal_manager = self.chassis.get_thermal_manager()
             if self.thermal_manager:
                 self.thermal_manager.initialize()
                 self.thermal_manager.load(ThermalControlDaemon.POLICY_FILE)
-                self.thermal_manager.init_thermal_algorithm(chassis)
+                self.thermal_manager.init_thermal_algorithm(self.chassis)
         except NotImplementedError:
             self.log_warning('Thermal manager is not supported on this platform')
         except Exception as e:
@@ -810,7 +810,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
         begin = time.time()
         try:
             if self.thermal_manager:
-                self.thermal_manager.run_policy(chassis)
+                self.thermal_manager.run_policy(self.chassis)
         except Exception as e:
             self.log_error('Caught exception while running thermal policy - {}'.format(repr(e)))
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Changed the chassis definition to be a part of the class do the chassis will be found in run() function
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Without the change, an error appears in syslog. 
```  ERR pmon#thermalctld: Caught exception while running thermal policy - NameError("name 'chassis' is not defined") ```
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
N/A
#### Additional Information (Optional)
