### PR TITLE
Add a call to apply app0 config before DP INIT

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1761,6 +1761,7 @@ class TestXcvrdScript(object):
         mock_xcvr_api = MagicMock()
         mock_xcvr_api.set_datapath_deinit = MagicMock(return_value=True)
         mock_xcvr_api.set_datapath_init = MagicMock(return_value=True)
+        mock_xcvr_api.apply_app0_configuration = MagicMock(return_value=True)
         mock_xcvr_api.tx_disable_channel = MagicMock(return_value=True)
         mock_xcvr_api.set_lpmode = MagicMock(return_value=True)
         mock_xcvr_api.set_application = MagicMock(return_value=True)
@@ -1888,6 +1889,7 @@ class TestXcvrdScript(object):
         task.task_stopping_event.is_set = MagicMock(side_effect=[False, False, True])
         task.task_worker()
         assert mock_xcvr_api.set_datapath_deinit.call_count == 1
+        assert mock_xcvr_api.apply_app0_configuration.call_count == 1
         assert mock_xcvr_api.tx_disable_channel.call_count == 1
         assert mock_xcvr_api.set_lpmode.call_count == 1
         assert get_cmis_state_from_state_db('Ethernet0', task.xcvr_table_helper.get_status_tbl(task.port_mapping.get_asic_id_for_logical_port('Ethernet0'))) == CMIS_STATE_AP_CONF

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1508,6 +1508,10 @@ class CmisManagerTask(threading.Thread):
                         # D.2.2 Software Deinitialization
                         api.set_datapath_deinit(host_lanes_mask)
 
+                        self.log_notice("Applying App0 configuration for port {}".format(lport))
+                        if not api.apply_app0_configuration():
+                            self.log_notice("{}: Could not apply application 0 configurations".format(lport))
+
                         # D.1.3 Software Configuration and Initialization
                         media_lanes_mask = self.port_dict[lport]['media_lanes_mask']
                         if not api.tx_disable_channel(media_lanes_mask, True):


### PR DESCRIPTION
depends on: https://github.com/noaOrMlnx/sonic-platform-common/pull/2
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
When NOS configures the CMIS modules, we need to be aware to a case where some of the lanes are disabled. 
According to CMIS spec, in that case, an application 0 is needed to make sure all disabled lanes are zeroed.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This was done according to CMIS specification document.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
This addition to CMIS thread was tested with a CMIS active cable, with only 4 active lanes (and 4 de-active). 
We made sure the link is up, right places are zeroed, and have traffic. 

#### Additional Information (Optional)
