### PR TITLE
Add regex escape to media_settings_parser

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -231,9 +231,10 @@ def get_media_settings_value(physical_port, key):
 
     def get_media_settings(key, media_dict):
         for dict_key in media_dict.keys():
-            if (re.match(dict_key, key[VENDOR_KEY]) or \
-                re.match(dict_key, key[VENDOR_KEY].split('-')[0]) # e.g: 'AMPHENOL-1234'
-                or re.match(dict_key, key[MEDIA_KEY]) ): # e.g: 'QSFP28-40GBASE-CR4-1M'
+            pattern = re.escape(dict_key)
+            if (re.match(pattern, key[VENDOR_KEY]) or \
+                re.match(pattern, key[VENDOR_KEY].split('-')[0]) # e.g: 'AMPHENOL-1234'
+                or re.match(pattern, key[MEDIA_KEY]) ): # e.g: 'QSFP28-40GBASE-CR4-1M'
                 return get_media_settings_for_speed(media_dict[dict_key], key[LANE_SPEED_KEY])
             elif key[MEDIUM_LANE_SPEED_KEY] in media_dict:
                 return media_dict[key[MEDIUM_LANE_SPEED_KEY]]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
In media_settings_parser, get_media_settings() there is a new use of regular expression. 
For strings that contain '+', regular expression matching will not provide the right value. 
so we must add escape to the pattern.

for example, 
'QSFP+C-active_cable_media_interface' pattern should modify to be 'QSFP\\+C\\-active_cable_media_interface'.
Then, matching between the exactly same 2 strings will return True.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The use of QSFP+ modules connected to the switch, with this change - https://github.com/sonic-net/sonic-platform-daemons/pull/471 that changes flow to compare media settings key using regex.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
with few types of modules - 
- QSFP+C-active_cable_media_interface
- QSFP-DD-sm_media_interface
- OSFP-8X-nm_850_media_interface

#### Additional Information (Optional)
